### PR TITLE
Typos & Rephrasing

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,8 +1,8 @@
-All participants in the Rands Leadership Slack are required to comply with the following Code of Conduct. Administrators (see below for definition of administrators) will enforce this code throughout the service ("Team"). 
+All participants in the Rands Leadership Slack are required to comply with the following Code of Conduct. Administrators (see below for definition of administrators) will enforce this code throughout the Rands Leadership Slack.
 
 # The Short Version
 
-Be respectful of other people; respectfully ask people to stop if you are bothered; respect privacy; understand we're mostly not-for-profit; and if you can’t resolve an issue contact the administrators. If you are being a problem, it will be apparent and you may be asked to leave the Team.
+Be respectful of other people; respectfully ask people to stop if you are bothered; respect privacy; understand we're mostly not-for-profit; and if you can’t resolve an issue then contact the Administrators. If you are being a problem, it will be apparent and you may be asked to leave the Rands Leadership Slack.
 
 # The Long Version
 
@@ -21,17 +21,17 @@ Respectful behavior includes but is not limited to:
 * If you’re not sure, ask someone instead of assuming. No, really. Just ask the administrators. We’d rather hear from you than hear about something you said or did after the fact, and we are here to help.
 * Don’t be a bystander. Role model respectful behaviour, but also help to address disrespect when you see it. 
 
-Disrespectful behavior outside this community may be considered a violation of this code of conduct at the discretion of the administrators.
+Disrespectful behavior outside this community may be considered a violation of this code of conduct at the discretion of the Administrators.
 
 ## Privacy
 
-This community is not a public space. However, no one has signed an Non-Disclosure Agreement (“NDA”) to participate, and you should not presume anything you say here will remain private, so act accordingly. Protect IP and legally-protected information.
+This community is not a public space. However, no one has signed an non-disclosure agreement (“NDA”) to participate, and you should not presume anything you say here will remain private, so act accordingly. Protect IP and legally-protected information.
 
 If you want to publicly disclose anything discussed here, use the [Chatham House Rule](https://www.chathamhouse.org/about/chatham-house-rule) as the guideline (“participants are free to use the information received, but neither the identity nor the affiliation of the speaker(s), nor that of any other participant, may be revealed”).
 
 For attribution of specific content found on this Slack, we ask that you ask the originator of the content for permission. If you don’t receive consent in a reasonable period of time, we ask that you credit the “Rands Leadership Slack.”
 
-## Not for Profit
+## Not For Profit
 
 This community is mostly not a place for commercial activity such as recruiting or marketing except in channels dedicated to that purpose which are:
 
@@ -44,11 +44,11 @@ If you join this community to just sell things and not contribute and learn, the
 
 ## Resolve Peacefully
 
-We believe peer to peer discussions, feedback, and corrections can help build a stronger, safer, and more welcoming community.
+We believe peer-to-peer discussions, feedback, and corrections can help build a stronger, safer, and more welcoming community.
 
 If you see someone violating any part of this Code of Conduct, we urge you to respectfully dissuade them from such behavior. Expect that others in the community wish to help keep the community respectful, and welcome your input in doing so.
 
-If you experience disrespectful behavior toward yourself or anyone else and feel in any way unable or unwilling to respond or resolve it respectfully (for any reason), please immediately bring it to the attention of an administrator. We want to hear from you about anything that you feel is disrespectful, threatening, or just something that could make someone feel distressed in any way. We will listen and work to resolve the matter.
+If you experience disrespectful behavior toward yourself or anyone else and feel in any way unable or unwilling to respond or resolve it respectfully (for any reason), please immediately bring it to the attention of an Administrator. We want to hear from you about anything that you feel is disrespectful, threatening, or just something that could make someone feel distressed in any way. We will listen and work to resolve the matter.
 
 ## Apologize for Mistakes
 
@@ -56,11 +56,11 @@ Should you catch yourself behaving disrespectfully, or be confronted as such, li
 
 ## Consequences
 
-If you are unable to resolve a situation peacefully, please refer to our [Incident Process](https://github.com/randsleadershipslack/documents-and-resources/blob/master/incident-process.md) and choose a course of action the suits the situation. 
+If you are unable to resolve a situation peacefully, please refer to our [Incident Process](https://github.com/randsleadershipslack/documents-and-resources/blob/master/incident-process.md) and choose a course of action that suits the situation. 
 
-If the administrators determine that a human is violating any part of this Code of Conduct, the administrators may take any action they deem appropriate within this Slack team, up to and including expulsion and exclusion from the Team.
+If the Administrators determine that a human is violating any part of this Code of Conduct, the Administrators may take any action they deem appropriate within this Slack team, up to and including expulsion and exclusion from the Rands Leadership Slack.
 
-As administrators, we will seek to resolve conflicts peacefully and in a manner that is positive for the community. We can’t foresee every situation, and thus if in the administrator's judgment the best thing to do is to ask a disrespectful individual to leave, we will do so. 
+As Administrators, we will seek to resolve conflicts peacefully and in a manner that is positive for the community. We can’t foresee every situation, and thus if in the Administrator's judgment the best thing to do is to ask a disrespectful individual to leave, we will do so. 
 
 ## Administrators
 
@@ -70,10 +70,10 @@ Rands ([Michael Lopp](mailto:feedback@randsinrepose.com))
 
 ## Thanks
 
-Thank you to every Rands Leadership community member for helping to making our home the respectful and inclusive community that it is.
+Thank you to every Rands Leadership Slack community member for helping to make our home the respectful and inclusive community that it is.
 
-Special thanks to [Chicago Camps](http://chicagocamps.org/code-of-conduct/), YxYY ([Yes and Yes Yes](http://www.yesandyesyes.com/)) and Hillary Hartley for sharing their Code of Conduct with us. We consider them as examples to look up to and emulate. We also thank the YxYY community member, [Tantek Çelik](http://tantek.com/), and the other organizers of [IndieWebCamp](http://indiewebcamp.com/) for creating and sharing the [Code of Conduct](http://indiewebcamp.com/code-of-conduct) on which this one is based. If you question the need for a Code of Conduct, please see [this](http://indiewebcamp.com/code-of-conduct-why).
+Special thanks to [Chicago Camps](http://chicagocamps.org/code-of-conduct/), YxYY ([Yes and Yes Yes](http://www.yesandyesyes.com/)), and Hillary Hartley for sharing their Code of Conduct with us. We consider them as examples to look up to and emulate. We also thank the YxYY community member [Tantek Çelik](http://tantek.com/), and the other organizers of [IndieWebCamp](http://indiewebcamp.com/) for creating and sharing the [Code of Conduct](http://indiewebcamp.com/code-of-conduct) on which this one is based. If you question the need for a Code of Conduct, please see [this](http://indiewebcamp.com/code-of-conduct-why).
 
-V2.1 of this Code of Conduct was published on October 27th, 2017.
+V2.2 of this Code of Conduct was published on February 14th, 2018.
 
 This Code of Conduct is released under the [CC0 public domain license](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/incident-process.md
+++ b/incident-process.md
@@ -1,6 +1,6 @@
 # Things Sometimes Go Sideways
 
-In any group of humans, things will sometimes go sideways. Whether it's simple unintentional miscommunication or more extreme unacceptable behavior, we need to have an agreed upon protocol to resolve these situations ourselves or to escalate in the case one-to-one resolutions in unachievable. 
+In any group of humans, things will sometimes go sideways. Whether it's simple unintentional miscommunication or more extreme unacceptable behavior, we need to have an agreed upon protocol to resolve these situations ourselves or to escalate in the case that one-to-one resolutions are unachievable. 
 
 This is the process for incident resolution at Rands Leadership Slack and process is [documented culture](http://randsinrepose.com/archives/the-process-myth/).
 
@@ -12,26 +12,26 @@ When an incident occurs, we ask that per the [Code of Conduct](https://github.co
 
 “If you see someone violating any part of this Code of Conduct, we urge you to respectfully dissuade them from such behavior. Expect that others in the community wish to help keep the community respectful, and welcome your input in doing so.”
 
-This is easier said than done, but this is Leadership Slack. Our expectations are that everyone here is hoping to learn about the craft of leadership; peaceful resolution of complex human situations is leadership 101.
+This is easier said than done, but this is Rands Leadership Slack. Our expectations are that everyone here is hoping to learn about the craft of leadership; peaceful resolution of complex human situations is leadership 101.
 
 ## Escalation
 
-Resolution amongst the individuals will not always be achievable. In this case, the reporter and/or observer of the incident has a choice. They can share the incident with #rands-slack-rules to seek feedback and perhaps resolve the incident or they can raise the incident with the administrator (see below for specifics). We understand the need for the latter workflow, but we highly encourage the former because, again, this is a leadership Slack. Our hope is that the debate will help educate this sub-community of humans interested in the rules and culture that govern this small corner of the Internet. 
+Resolution amongst the individuals will not always be achievable. In this case, the reporter or observer of the incident has a choice. They can share the incident with #rands-slack-rules to seek feedback, and perhaps resolve the incident, or they can raise the incident with the Administrators (see below for specifics). We understand the need for the latter workflow, but we highly encourage the former because, again, this is a community focused on leadership. Our hope is that the debate will help educate this sub-community of humans interested in the rules and culture that govern this small corner of the Internet. 
 
-When ready and if appropriate, the reporter needs to send the administrator a direct message with the following information. 
+When ready and if appropriate, the reporter needs to send an Administrator a direct message with the following information. 
 
-1. What’s the nature of the incident and/or CoC violation? 
+1. What’s the nature of the incident or Code of Conduct violation? 
 2. Who is involved in this incident?
 3. What material supports this situation?
 4. Any privacy concerns? (Reporter consent is required before sharing any information regarding the incident)
 
-With this information in hand, the administrator will strive to respond to the reporter as quickly as possible with an estimate of when they think they’ll be able to triage and resolve this incident. In extreme cases, the administrator may suspend one or more accounts until they are able to triage and resolve an incident. 
+With this information in hand, the Administrators will strive to respond to the reporter as quickly as possible with an estimate of when they think they’ll be able to triage and resolve this incident. In extreme cases, the administrator may suspend one or more accounts until they are able to triage and resolve an incident. 
 
-Incident resolution can vary from hours to days depending on the availability of those involved. Once the incident is resolved, the administrator will communicate the resolution to the reporter and other other parties relevant to the incident. In extreme cases, the administrator will communicate the resolution with #rands-slack-rules with reporter permission. 
+Incident resolution can vary from hours to days depending on the availability of those involved. Once the incident is resolved, the Administrators will communicate the resolution to the reporter and other other parties relevant to the incident. In extreme cases, the Administrators will communicate the resolution with #rands-slack-rules with reporter permission. 
 
 ## Appeal of Account Suspension
 
-In cases the result in account suspension, the individual suspended may appeal the decision starting one week after the suspension by sending a mail to the administrator with justification for overturning the appeal. If a suspension is overturned, the new context will be shared with #rands-slack-rules
+In cases that result in account suspension, the individual suspended may appeal the decision starting one week after the suspension by sending a mail to an Administrator with justification for overturning the appeal. If a suspension is overturned, the new context will be shared with #rands-slack-rules
 
 # FAQ:
 
@@ -44,3 +44,8 @@ The administrator(s) of Rands Leadership as of January 29th, 2018:
 
 @rands ([Michael Lopp](mailto:feedback@randsinrepose.com))
 
+## Version and Copyright
+
+V1.3 of this Code of Conduct was published on February 14th, 2018.
+
+This Code of Conduct is released under the [CC0 public domain license](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Hi Rands, I'm working to organize a community on Slack and am starting with the COC and incident process from Leadership because they're pretty awesome. In editing for this other group, I found a few things I thought ought to be corrected or rephrased for clarity.

I think the most structural change was updating references to use big-A "Administrators" and adding a version/license block to the incident process.

Cheers!

-jth