### PR TITLE
Add #remote-jobs to commercial channel list

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -39,6 +39,7 @@ This community is mostly not a place for commercial activity such as recruiting 
 * #consulting-gigs
 * #conferences
 * #services 
+* #remote-jobs
 
 If you join this community to just sell things and not contribute and learn, the community will quickly notice. If you are wondering where you can post commercial things, ask in #rands-slack-rules. 
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -35,11 +35,11 @@ For attribution of specific content found on this Slack, we ask that you ask the
 
 This community is mostly not a place for commercial activity such as recruiting or marketing except in channels dedicated to that purpose which are:
 
-* #jobs
-* #consulting-gigs
 * #conferences
-* #services 
+* #consulting-gigs
+* #jobs
 * #remote-jobs
+* #services
 
 If you join this community to just sell things and not contribute and learn, the community will quickly notice. If you are wondering where you can post commercial things, ask in #rands-slack-rules. 
 


### PR DESCRIPTION
Since the code of conduct was last updated, someone has created a `#remote-jobs` channel. This seems worth adding to the list.

I wasn’t quite sure where in the list to put this new channel, so I figured it made sense to sort the whole list for the sake of any future additions. I’ve put that in as a separate commit in case there’s some context I’m missing that means alphabetical order doesn’t make sense.