### PR TITLE
Code of Conduct (and associated document) updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This repository collects documents and resources for the membership of the Rands Leadership Slack.
 
 * [Code of Conduct](https://github.com/randsleadershipslack/documents-and-resources/blob/master/code-of-conduct.md)
+* [Deleting Content](https://github.com/randsleadershipslack/documents-and-resources/blob/master/deleting-content.md)
 * [Incident Process](https://github.com/randsleadershipslack/documents-and-resources/blob/master/incident-process.md)
 * [How to Rands](https://github.com/randsleadershipslack/documents-and-resources/blob/master/howtorands.md)
 * [Inclusive Language](https://github.com/randsleadershipslack/documents-and-resources/blob/master/InclusiveLanguage.md)

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -40,6 +40,7 @@ Channels for commercial purposes include:
 * #conferences
 * #consulting-gigs
 * #forsale
+* #ibuiltsomething
 * #iwrotesomething
 * #jobs
 * #remote-jobs

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -75,11 +75,11 @@ Should you catch yourself behaving disrespectfully, or be confronted as such, li
 
 ## Consequences
 
-If you are unable to resolve a situation peacefully, please refer to our [Incident Process](https://github.com/randsleadershipslack/documents-and-resources/blob/master/incident-process.md) and choose a course of action that suits the situation. 
+If you are unable to resolve a situation peacefully, please refer to our [Incident Process](https://github.com/randsleadershipslack/documents-and-resources/blob/master/incident-process.md) and choose a course of action that suits the situation.
 
 If the Administrators determine that a human is violating any part of this Code of Conduct, the Administrators may take any action they deem appropriate within this Slack team, up to and including expulsion and exclusion from the Rands Leadership Slack.
 
-As Administrators, we will seek to resolve conflicts peacefully and in a manner that is positive for the community. We can’t foresee every situation, and thus if in the Administrator's judgment the best thing to do is to ask a disrespectful individual to leave, we will do so. 
+As Administrators, we will seek to resolve conflicts peacefully and in a manner that is positive for the community. We can’t foresee every situation, and thus if in the Administrator's judgment the best thing to do is to ask a disrespectful individual to leave, we will do so.
 
 ## Administrators
 
@@ -92,7 +92,9 @@ The administrator(s) of Rands Leadership as of November 14th, 2019:
 * @supine
 * @rands (also the workspace owner)
 
-The current term of the volunteer administrations is November 14th, 2019 until November 14th, 2020. 
+You can also contact them via the @admins group or by posting in the #rands-admins channel.
+
+The current term of the volunteer administrations is November 14th, 2019 until November 14th, 2020.
 
 ## Thanks
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -33,25 +33,32 @@ For attribution of specific content found on this Slack, we ask that you ask the
 
 ## Not For Profit
 
-This community is mostly not a place for obvious commercial activity such as recruiting or marketing except in channels dedicated to that purpose which include:
+While this community is designed to help aspects of leadership, and that frequently benefit whatever company or individual a member is currently working for, this is not a place for obvious commercial activities such as recruiting, marketing, or other solicitation, except in channels dedicated to that purpose.
+
+Channels for commercial purposes include:
 
 * #conferences
 * #consulting-gigs
+* #forsale
+* #iwrotesomething
 * #jobs
 * #remote-jobs
 * #services
+* #wedidit
 
-Additionally, geographically-focused channels (i.e. #colorado-connections, #new-york-city, similar) have a higher tolerance for specific kinds of commercial activity focused on events based in that region.
+Even channels dedicated to commercial purposes are dedicated to a specific aspect of commercial purpose; it is just as unwelcome to post an unrelated commercial offering there as it is to post in non-commercial channels.
 
-Non-obvious commercial activity is less obvious. Well-intentioned user surveys of a specific channel are a common request and we ask that you:
+Additionally, some geographically-focused channels have a higher tolerance for specific kinds of commercial activity focused on events based in that region. We recommend the asking protocol below for these channels as well.
 
-* Ask permission of the channel.
-* State clear intent for the purpose of the survey.
-* Listen to the response of your peers.
+Non-obvious commercial activity includes things such as well-intentioned user surveys of a specific channel or responding to a request for tools or services with information about what your company provides.  In these situations, we ask that you:
 
-We believe the above protocol is a useful approach for other types of non-obvious commercial activity.
+* Ask permission of the channel *before* posting the solicitation or information
+* State clear intent for the purpose
+* Listen to the response of your peers
 
-If you join this community simply to take value from the community rather than contribute, the community will quickly notice and react. If you are wondering whether a specific action is commercial or not, please ask and calibrate in #rands-slack-rules.
+We believe the above protocol is generally useful and should be used when there are any doubts.
+
+If you join this community simply to take value rather than contribute, the community will quickly notice and react. If you are wondering whether a specific action is commercial or not, please ask and calibrate in one of the the channels dedicated to helping people find their way (#how-to-rands or #rands-slack-rules).
 
 ## Resolve Peacefully
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -102,6 +102,6 @@ Thank you to every Rands Leadership Slack community member for helping to make o
 
 Special thanks to [Chicago Camps](http://chicagocamps.org/code-of-conduct/), YxYY ([Yes and Yes Yes](http://www.yesandyesyes.com/)), and Hillary Hartley for sharing their Code of Conduct with us. We consider them as examples to look up to and emulate. We also thank the YxYY community member [Tantek Çelik](http://tantek.com/), and the other organizers of [IndieWebCamp](http://indiewebcamp.com/) for creating and sharing the [Code of Conduct](http://indiewebcamp.com/code-of-conduct) on which this one is based. If you question the need for a Code of Conduct, please see [this](http://indiewebcamp.com/code-of-conduct-why).
 
-V2.3 of this Code of Conduct was published on April 9th, 2019.
+V2.4 of this Code of Conduct was published on January 23rd, 2020.
 
 This Code of Conduct is released under the [CC0 public domain license](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,8 +1,8 @@
-All participants in the Rands Leadership Slack are required to comply with the following Code of Conduct. Administrators (see below for definition of administrators) will enforce this code throughout the Rands Leadership Slack.
+All participants in the Rands Leadership Slack are required to comply with the following Code of Conduct. Administrators (see below for definition of Administrators) will enforce this code throughout the Rands Leadership Slack.
 
 # The Short Version
 
-Be respectful of other people, respectfully ask people to stop if you are bothered; respect privacy; understand we’re mostly not-for-profit; and if you can’t resolve an issue with someone else you should contact the Administrator. If you are being a problem, it will be made clear to you, and you may be asked to leave the Rands Leadership Slack. 
+Be respectful of other people, respectfully ask people to stop if you are bothered; respect privacy; understand we’re mostly not-for-profit; and if you can’t resolve an issue with someone else you should contact the Administrators. If you are being a problem, it will be made clear to you, and you may be asked to leave the Rands Leadership Slack.
 
 # The Long Version
 
@@ -18,7 +18,7 @@ Respectful behavior includes but is not limited to:
 
 * Be considerate, kind, constructive, and helpful.
 * Avoid demeaning, discriminatory, harassing, hateful, or physically threatening behavior, speech, and imagery.
-* If you’re not sure, ask someone instead of assuming. No, really. Just ask the administrators. We’d rather hear from you than hear about something you said or did after the fact, and we are here to help.
+* If you’re not sure, ask someone instead of assuming. No, really. Just ask the Administrators. We’d rather hear from you than hear about something you said or did after the fact, and we are here to help.
 * Don’t be a bystander. Role model respectful behaviour, but also help to address disrespect when you see it. 
 
 Disrespectful behavior outside this community may be considered a violation of this code of conduct at the discretion of the Administrators.
@@ -83,7 +83,7 @@ As Administrators, we will seek to resolve conflicts peacefully and in a manner 
 
 ## Administrators
 
-The administrator(s) of Rands Leadership as of November 14th, 2019:
+The Administrator(s) of Rands Leadership as of November 14th, 2019:
 
 * @moj_hoss
 * @pixeldiva
@@ -94,7 +94,7 @@ The administrator(s) of Rands Leadership as of November 14th, 2019:
 
 You can also contact them via the @admins group or by posting in the #rands-admins channel.
 
-The current term of the volunteer administrations is November 14th, 2019 until November 14th, 2020.
+The current term of the volunteer Administrations is November 14th, 2019 until November 14th, 2020.
 
 ## Thanks
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -10,7 +10,7 @@ Be respectful of other people, respectfully ask people to stop if you are bother
 
 The Rands Leadership Slack is an intentionally positive online community dedicated to developing the craft of leadership. We recognize and celebrate the creativity and collaboration of our independent members and the diversity of skills, talents, experiences, cultures, and opinions that they bring to your community. 
 
-The Rands Leadership Slack is an inclusive environment, based on treating all individuals respectfully, regardless of gender or gender identity (including transgender status), sexual orientation, age, disability, nationality, ethnicity, religion (or lack thereof), or career path.
+The Rands Leadership Slack is an inclusive environment, based on treating all individuals respectfully, regardless of gender or gender identity (including transgender status), sexual orientation, age, disability, nationality, ethnicity, religion (or lack thereof), political affiliation, or career path.
 
 We value respectful behavior above individual opinions.
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -75,6 +75,8 @@ Should you catch yourself behaving disrespectfully, or be confronted as such, li
 
 ## Consequences
 
+If you feel a message should be deleted, please refer to our overview of [Deleting Content](https://github.com/randsleadershipslack/documents-and-resources/blob/master/deleting_content.md).
+
 If you are unable to resolve a situation peacefully, please refer to our [Incident Process](https://github.com/randsleadershipslack/documents-and-resources/blob/master/incident-process.md) and choose a course of action that suits the situation.
 
 If the Administrators determine that a human is violating any part of this Code of Conduct, the Administrators may take any action they deem appropriate within this Slack team, up to and including expulsion and exclusion from the Rands Leadership Slack.

--- a/deleting-content.md
+++ b/deleting-content.md
@@ -24,7 +24,7 @@ Additional consequences beyond the removal of content are up to the acting Admin
 
 ## Administrators
 
-The current roster of Administrator(s) is maintained in the primary [Code of Conduct](https://github.com/randsleadershipslack/documents-and-resources/blob/master/code-of-conduct.md) document.
+The current roster of Administrators is maintained in the primary [Code of Conduct](https://github.com/randsleadershipslack/documents-and-resources/blob/master/code-of-conduct.md) document.
 
 ## Version and Copyright
 

--- a/deleting-content.md
+++ b/deleting-content.md
@@ -1,0 +1,29 @@
+# Things Are Sometimes Better Unread
+
+In any large message board with a diverse group of humans, communication can break down.  Whether it's unintential miscommunication or intentional boundary pushing, admins are occasionally requested to delete a message someone wrote in the public channels.
+
+This is the process for content removal at Rands Leadership Slack and process is [documented culture](http://randsinrepose.com/archives/the-process-myth/).
+
+# In Brief
+
+* Admins may delete messages that violate the Code of Conduct
+* The authors of those messages will be notified and may be given a chance to modify the message themselves.
+
+# What, When, and How
+
+Admins may come across or be notified of content on RLS that violates the Code of Conduct. In some situations, this may lead to an admin deleting the message (or messages) that violate the CoC. Messages that are most likely to be deleted are commercial solicitations, disrespectful messages to other members, or links to disturbing or distressing content without appropriate measures to warn of or hide the content (including image uploads and unfurls).
+
+Ideally, another RLS member notices this content and contacts the original poster, who then modifies or deletes the message so that it is no longer problematic. In this case, no further admin action is required. If admin action is desired, due to lack of response or any other reason, an admin will notify the original poster of the violation and the need to reword or remove the problematic message. The admin will also specify a time after which admin action will be taken to delete the content if it is not addressed. This time may be as little as a few minutes, or as much as 24 hours.
+
+The determination of how much time is allowed is up to the acting admin, but the following context will be used to help determine the time before admin action:
+* How blatant the violation is
+* How likely it is to be seen by others (higher-volume channels get less time)
+* How likely it is to trigger negative reactions in others
+
+Additional consequences beyond the removal of content are up to the acting admin, per the same incident process found in the [Incident Process](https://github.com/randsleadershipslack/documents-and-resources/blob/master/incident-process.md)
+
+## Version and Copyright
+
+V1.51 of this Code of Conduct was published on November 7th, 2019.
+
+This Code of Conduct is released under the [CC0 public domain license](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/deleting-content.md
+++ b/deleting-content.md
@@ -28,6 +28,6 @@ The current roster of Administrator(s) is maintained in the primary [Code of Con
 
 ## Version and Copyright
 
-V1.51 of this Code of Conduct was published on November 7th, 2019.
+V2.4 of this Code of Conduct was published on January 23rd, 2020.
 
 This Code of Conduct is released under the [CC0 public domain license](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/deleting-content.md
+++ b/deleting-content.md
@@ -26,8 +26,3 @@ Additional consequences beyond the removal of content are up to the acting Admin
 
 The current roster of Administrators is maintained in the primary [Code of Conduct](https://github.com/randsleadershipslack/documents-and-resources/blob/master/code-of-conduct.md) document.
 
-## Version and Copyright
-
-V2.4 of this Code of Conduct was published on January 23rd, 2020.
-
-This Code of Conduct is released under the [CC0 public domain license](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/deleting-content.md
+++ b/deleting-content.md
@@ -1,6 +1,6 @@
 # Things Are Sometimes Better Unread
 
-In any large message board with a diverse group of humans, communication can break down.  Whether it's unintential miscommunication or intentional boundary pushing, admins are occasionally requested to delete a message someone wrote in the public channels.
+In any large message board with a diverse group of humans, communication can break down.  Whether it's unintential miscommunication or intentional boundary pushing, Administrators are occasionally requested to delete a message someone wrote in the public channels.
 
 This is the process for content removal at Rands Leadership Slack and process is [documented culture](http://randsinrepose.com/archives/the-process-myth/).
 
@@ -11,16 +11,16 @@ This is the process for content removal at Rands Leadership Slack and process is
 
 # What, When, and How
 
-Admins may come across or be notified of content on RLS that violates the Code of Conduct. In some situations, this may lead to an admin deleting the message (or messages) that violate the CoC. Messages that are most likely to be deleted are commercial solicitations, disrespectful messages to other members, or links to disturbing or distressing content without appropriate measures to warn of or hide the content (including image uploads and unfurls).
+Admins may come across or be notified of content on RLS that violates the Code of Conduct. In some situations, this may lead to an Administrator deleting the message (or messages) that violate the CoC. Messages that are most likely to be deleted are commercial solicitations, disrespectful messages to other members, or links to disturbing or distressing content without appropriate measures to warn of or hide the content (including image uploads and unfurls).
 
-Ideally, another RLS member notices this content and contacts the original poster, who then modifies or deletes the message so that it is no longer problematic. In this case, no further admin action is required. If admin action is desired, due to lack of response or any other reason, an admin will notify the original poster of the violation and the need to reword or remove the problematic message. The admin will also specify a time after which admin action will be taken to delete the content if it is not addressed. This time may be as little as a few minutes, or as much as 24 hours.
+Ideally, another RLS member notices this content and contacts the original poster, who then modifies or deletes the message so that it is no longer problematic. In this case, no further Administrator action is required. If Administrator action is desired, due to lack of response or any other reason, an Administrator will notify the original poster of the violation and the need to reword or remove the problematic message. The Administrator will also specify a time after which Administrator action will be taken to delete the content if it is not addressed. This time may be as little as a few minutes, or as much as 24 hours.
 
-The determination of how much time is allowed is up to the acting admin, but the following context will be used to help determine the time before admin action:
+The determination of how much time is allowed is up to the acting Administrator, but the following context will be used to help determine the time before Administrator action:
 * How blatant the violation is
 * How likely it is to be seen by others (higher-volume channels get less time)
 * How likely it is to trigger negative reactions in others
 
-Additional consequences beyond the removal of content are up to the acting admin, per the same incident process found in the [Incident Process](https://github.com/randsleadershipslack/documents-and-resources/blob/master/incident-process.md)
+Additional consequences beyond the removal of content are up to the acting Administrator, per the same incident process found in the [Incident Process](https://github.com/randsleadershipslack/documents-and-resources/blob/master/incident-process.md)
 
 ## Version and Copyright
 

--- a/deleting-content.md
+++ b/deleting-content.md
@@ -22,6 +22,10 @@ The determination of how much time is allowed is up to the acting Administrator,
 
 Additional consequences beyond the removal of content are up to the acting Administrator, per the same incident process found in the [Incident Process](https://github.com/randsleadershipslack/documents-and-resources/blob/master/incident-process.md)
 
+## Administrators
+
+The current roster of Administrator(s) is maintained in the primary [Code of Conduct](https://github.com/randsleadershipslack/documents-and-resources/blob/master/code-of-conduct.md) document.
+
 ## Version and Copyright
 
 V1.51 of this Code of Conduct was published on November 7th, 2019.

--- a/incident-process.md
+++ b/incident-process.md
@@ -31,9 +31,9 @@ For both paths, with this information in hand, the Administrators will provide t
 
 In the case of a raised concern, the understanding is there *may be no action* other than administrative awareness. 
 
-In extreme cases involving formal complaints, the Administrator may suspend one or more accounts until they can triage and resolve an incident.
+In extreme cases involving formal complaints, the Administrators may suspend one or more accounts until they can triage and resolve an incident.
 
-Incidents are confidential. The Administrator will not provide any information to parties not involved in any incidents. The lone exception is the case where an incident occurs in a public channel; the Administrator will consult those involved in the incident before disclosing any information.
+Incidents are confidential. The Administrators will not provide any information to parties not involved in any incidents. The lone exception is the case where an incident occurs in a public channel; the Administrators will consult those involved in the incident before disclosing any information.
 
 ## Appeal of Account Suspension
 
@@ -47,7 +47,7 @@ In cases that result in account suspension, the individual suspended may appeal 
 
 ## Administrators
 
-The current roster of Administrator(s) is maintained in the primary [Code of Conduct](https://github.com/randsleadershipslack/documents-and-resources/blob/master/code-of-conduct.md) document.
+The current roster of Administrators is maintained in the primary [Code of Conduct](https://github.com/randsleadershipslack/documents-and-resources/blob/master/code-of-conduct.md) document.
 
 ## Version and Copyright
 

--- a/incident-process.md
+++ b/incident-process.md
@@ -51,6 +51,6 @@ The current roster of Administrator(s) is maintained in the primary [Code of Con
 
 ## Version and Copyright
 
-V1.51 of this Code of Conduct was published on November 7th, 2019.
+V2.4 of this Code of Conduct was published on January 23rd, 2020.
 
 This Code of Conduct is released under the [CC0 public domain license](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/incident-process.md
+++ b/incident-process.md
@@ -47,9 +47,7 @@ In cases that result in account suspension, the individual suspended may appeal 
 
 ## Administrators
 
-The administrator(s) of Rands Leadership as of November 7th, 2019:
-
-@rands ([Michael Lopp](mailto:feedback@randsinrepose.com))
+The current roster of Administrator(s) is maintained in the primary [Code of Conduct](https://github.com/randsleadershipslack/documents-and-resources/blob/master/code-of-conduct.md) document.
 
 ## Version and Copyright
 


### PR DESCRIPTION
These are primarily as per discussion in the #rands-coc channel over the past two months.  Some small changes were made without discussion; these include:
* Referring to the primary CoC document for current administrator(s)
* Making the phrasing used for administrator(s) account for a team of multiple admins
* Bumping the version number