### PR TITLE
Fix typo in date of Code of Conduct update

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -161,4 +161,4 @@ Thanks to [Tantek Çelik](http://tantek.com/), and the other organizers of [Indi
 
 This Code of Conduct is released under the [CC0 public domain license](https://creativecommons.org/publicdomain/zero/1.0/).
 
-V3.02 of this Code of Conduct was published on August 29th, 2002.
+V3.02 of this Code of Conduct was published on August 29th, 2021.


### PR DESCRIPTION
The publish date of the Code of Conduct was incorrectly given the year of 2002.  The commit https://github.com/randsleadershipslack/documents-and-resources/commit/1d487c7c953c51dc8d5c2180ebd06e43dd28dc68 was dated August 29th, 2021, so this edit changes the year of the date to match.