### PR TITLE
Quick start v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ This repository collects documents and resources for the membership of the Rands
 * [Incident Process](https://github.com/randsleadershipslack/documents-and-resources/blob/master/incident-process.md)
 * [How to Rands](https://github.com/randsleadershipslack/documents-and-resources/blob/master/howtorands.md)
 * [Inclusive Language](https://github.com/randsleadershipslack/documents-and-resources/blob/master/InclusiveLanguage.md)
+* [Quick-Start Guide](https://github.com/randsleadershipslack/documents-and-resources/blob/main/rls-quick-start-guide.md)

--- a/rls-quick-start-guide.md
+++ b/rls-quick-start-guide.md
@@ -4,19 +4,27 @@ Hello, RLS members new and old! Welcome to the Rands Leadership Slack quick-star
 
 RLS is a big community! As of June 2022, RLS membership was the same size as East Peoria, Illinois with 22,620 people. As RLS continues to grow, it can be harder to figure out where to get started. This quick-start guide is intended to give you that starting point to exploring and participating in this community. 
 
-And please be assured that we do want you - _yes, you!_ - to participate. You are not too junior, or too new, or not leader-y enough to contribute. Our community benefits from being able to discuss and learn from all of our perspectives and experiences, and it's what we love about being in RLS.
+And please be assured that we do want you - _yes, you!_ - to participate. You are not too junior, or too new, or not leader-y enough to contribute. Our community benefits from being able to discuss and learn from all of our perspectives and experiences, and it's one of the great things about being in RLS.
+
+That being said - active participation is not mandatory! We know that some folks prefer to hang back and take it all in, and people who choose to be more passive participants are still welcome here.
 
 ## Code of Conduct
 
 Please make sure you read and understand the RLS [Code of Conduct](https://github.com/randsleadershipslack/documents-and-resources/blob/main/code-of-conduct.md). We respect it and take it quite seriously!
 
-## Welcome / Tackling Imposter Syndrome
+### Commercial Activity
 
-Remember what we said a minute ago about wanting you to participate here? We really do mean it - but we also understand that can be easier said than done. 
+This community is especially sensitive to appropriate interactions around commercial activity. The CoC has a [detailed section](https://github.com/randsleadershipslack/documents-and-resources/blob/main/code-of-conduct.md#not-for-profit-mostly) around these expectations that you should read, but the tl;dr is that commercial behavior is strictly limited to a select few channels, and there is an especially low tolerance for community members who choose to repeatedly ignore these CoC guidelines.
+
+### DM Etiquette
+
+Our CoC has specific guidelines around unsolicited DMs and generally leans toward any kind of unsolicited DM being a breach of the CoC. If you're OK with people reaching out to you via DMs, you may want to mention it in your profile. 
+
+## Imposter Syndrome
 
 This is a big place, and it can feel intimidating. On the surface, Rands Leadership Slack looks like a group of high-performing leaders with extensive experience and a wide range of expertise. And that's true - but that's not all we are. We are humans with strengths and weaknesses. Our community is a fabric of many individuals from different backgrounds, companies, countries, and working cultures. We each bring different perspectives to the discussion - and so can you.
 
-We know what imposter syndrome is. Many of us experience it regularly in some form, and you may well feel it too upon joining. Finding yourself amongst a self-selecting group of leaders, often in high profile roles, you can suddenly feel smaller than you did before. We strongly encourage you to push past this. Start contributing. Find your own voice, share your own insights, and ask questions where you want to learn. We welcome you and hope you will quickly find it rewarding to engage with us.
+We know what imposter syndrome is. Many of us experience it regularly in some form, and you may well feel it too upon joining. Finding yourself amongst a self-selecting group of leaders, often in high profile roles, you can suddenly feel smaller than you did before. We strongly encourage you to push past this. Start contributing. Find your own voice, share your own insights, and ask questions where you want to learn. We welcome you and hope you will quickly find it rewarding to engage with us. 
 
 We treat leadership as a human quality, not just a job title. We make mistakes and learn from each other. We support and encourage each other. We're a community.
 
@@ -36,8 +44,6 @@ Rands Leadership Slack has many (many) channels. We could not hope to describe a
 - **`#help-and-advice`:** If there's not a more specific channel that's relevant to your question, you can always ask in this channel. 
 - **`#anonymous-help-and-advice`:** For various reasons, there are times where someone may not feel comfortable asking for advice publicly in RLS. This channel was created to support those times and allow members to create an anonymous top-level post using a channel workflow. The donwside is that it can remove the ability to have deeper discussions, since the original poster cannot respond anonymously in threads to participate.
 - **`#lobby-*`:** Lobby channels are public channels that enable members to request admission to private channels, which would otherwise be undiscoverable. Right now only two exist, `#lobby-adoption` and `#lobby-non-binary-and-women`, and you can see past discussions about the implementation and use of `#lobby-*` channels in `#rands-slack-culture`.
-- **`🔒#the-treehouse`:** a private (but not secret) channel for non-binary folks and women. If you'd like to join this channel, please use the workflow in `#lobby-non-binary-and-women` to make a request!
-  - Note for private channels: if someone types the name of a private channel that you have not joined, the channel name will be obfuscated to you and appear like this in Slack: **`🔒 private channel`**.
 
 ## Discovering New Channels
 
@@ -52,14 +58,6 @@ Here are some channels to join that are good for helping you discover other chan
 ## Reacji Channelers
 
 Several channels are set up with a workflow to automatically cross-post in a different channel based on specific emoji reactions (also known as reacjis). In Slack, you can use a slash command to view all of the channels with this cross-post workflow: `/reacji-channeler list`.
-
-## (Some) Reacjis and Their Meaning
-
-Some reacjis have a specific connotation that's not immediately clear. This is a non-exhaustive list of some that tend to be used more often:
-
-- **`:raccoon:`** has various forms, and is used to indicate that someone's contribution to a discussion is off-topic. This usage predates RLS, and more context can be found [here](https://techcrunch.com/2017/12/04/how-slack-uses-a-raccoon-to-keep-distractions-on-slack-at-bay/?guccounter=1).
-- **`:royr:` and `:ohroy:`** have two use cases. The first is to use the reacji channeler on something that Roy Rapoport (the most prolific poster on RLS) has said so that it automatically cross-posts into `#royquotes`. The second is to appreciate a bit of sarcasm or a dad joke in the spirit of Roy, even if he was not the one posting it. (The cross-posting action is still triggered in this use, it just wasn't the main intent.)
-- **`:shields-up`, `:shields-at50:`, `:shields-down:`, and `:shields-omgbbq:`** refer the the progression in "job happiness" discussed in [this blog post](http://randsinrepose.com/archives/shields-down/). Instead of being used as reacji, people usually add them into their profile status so that it's visible next to their name or username. 
 
 ## Slackbot Custom Responses
 

--- a/rls-quick-start-guide.md
+++ b/rls-quick-start-guide.md
@@ -44,6 +44,9 @@ Rands Leadership Slack has many (many) channels. We could not hope to describe a
 - **`#help-and-advice`:** If there's not a more specific channel that's relevant to your question, you can always ask in this channel. 
 - **`#anonymous-help-and-advice`:** For various reasons, there are times where someone may not feel comfortable asking for advice publicly in RLS. This channel was created to support those times and allow members to create an anonymous top-level post using a channel workflow. The donwside is that it can remove the ability to have deeper discussions, since the original poster cannot respond anonymously in threads to participate.
 - **`#lobby-*`:** Lobby channels are public channels that enable members to request admission to private channels, which would otherwise be undiscoverable. Right now only two exist, `#lobby-adoption` and `#lobby-non-binary-and-women`, and you can see past discussions about the implementation and use of `#lobby-*` channels in `#rands-slack-culture`.
+- **`🔒#the-treehouse`:** a private (but not secret) channel for non-binary folks and women. If you'd like to join this channel, please use the workflow in `#lobby-non-binary-and-women` to make a request!
+- **`#lgbt`:** public channel; channel description is _discussion for and by people in all areas of the sexuality and gender spectra. ALL identities welcome; no invalidation or gatekeeping allowed._
+- **`#gender-diversity`:** public channel; channel description is _for folx who may like binary code but not gender binaries._
 
 ## Discovering New Channels
 


### PR DESCRIPTION
Some additional changes for review based on feedback from Rands.

### Changes

- Added bit of welcoming verbiage for members who lurk vs active participation.
- Added tl;dr around commercial activity, since it's one of the more important CoC guidelines here, and one that people feel very strongly about.
- Added a bit about being specific if you welcome DM participation, since there are some folks who do encourage it but the CoC discourages it by default.
- Clarified the imposter syndrome section by unlinking it to active participation (related to welcoming lurkers above) 
- ~~Removed the mention of #the-treehouse channel; it felt lopsided to only call out this single channel for under-represented / historically excluded groups.~~
- Reacjis section felt a little hodgepodge and less useful than the other sections here. 