### PR TITLE
Update code-of-conduct.md for readability

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -199,7 +199,7 @@ You can contact them directly or post your questions or concerns in the [#rls-ad
 
 As part of the role, Administrators have information not available to all users. This information includes:
 
-* A member provides email addresses as part of our sign-up process.
+* Any member provided email addresses as part of our sign-up process.
 * Information contained within member requests to join the community. This might include email, name, and occupation.
 * Access log information provided by the Slack administrator interface. This includes name, login times, login device, and IP.
 


### PR DESCRIPTION
Updates administrator accessible information point 1 for readability.
I also noticed the issue being addressed by [this PR](https://github.com/randsleadershipslack/documents-and-resources/pull/47) but didn’t want to add noise by duplicating that change.