### PR TITLE
Fix branch names to `main` in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,17 @@
 This repository collects documents and resources for the membership of the Rands Leadership Slack.
 
 ## Community Guidelines
-* [Code of Conduct](https://github.com/randsleadershipslack/documents-and-resources/blob/master/code-of-conduct.md) - The guiding principles for participation in the Rands Leadership Slack, outlining expectations for respectful behavior and community standards.
-* [Incident Process](https://github.com/randsleadershipslack/documents-and-resources/blob/master/incident-process.md) - Procedures for addressing code of conduct violations and community disputes, with steps for both member-driven resolution and administrator involvement.
-* [Deleting Content](https://github.com/randsleadershipslack/documents-and-resources/blob/master/deleting-content.md) - Guidelines explaining when and how content may be removed from the community, and the content review process for problematic messages.
-* [Commercial Activity Guidelines](https://github.com/randsleadershipslack/documents-and-resources/blob/master/commercial-activity.md) - Detailed explanations about what constitutes commercial activity in RLS, with examples and insights on appropriate business-related interactions.
-* [Job Posting Guidelines](https://github.com/randsleadershipslack/documents-and-resources/blob/master/job-posting.md) - Specifications for how to effectively share job opportunities within the community, including recommended details to include in postings.
+* [Code of Conduct](https://github.com/randsleadershipslack/documents-and-resources/blob/main/code-of-conduct.md) - The guiding principles for participation in the Rands Leadership Slack, outlining expectations for respectful behavior and community standards.
+* [Incident Process](https://github.com/randsleadershipslack/documents-and-resources/blob/main/incident-process.md) - Procedures for addressing code of conduct violations and community disputes, with steps for both member-driven resolution and administrator involvement.
+* [Deleting Content](https://github.com/randsleadershipslack/documents-and-resources/blob/main/deleting-content.md) - Guidelines explaining when and how content may be removed from the community, and the content review process for problematic messages.
+* [Commercial Activity Guidelines](https://github.com/randsleadershipslack/documents-and-resources/blob/main/commercial-activity.md) - Detailed explanations about what constitutes commercial activity in RLS, with examples and insights on appropriate business-related interactions.
+* [Job Posting Guidelines](https://github.com/randsleadershipslack/documents-and-resources/blob/main/job-posting.md) - Specifications for how to effectively share job opportunities within the community, including recommended details to include in postings.
 
 ## Resources
-* [How to Rands](https://github.com/randsleadershipslack/documents-and-resources/blob/master/howtorands.md) - A manager README template describing leadership style, working relationships, and communication preferences to accelerate team productivity.
-* [Inclusive Language](https://github.com/randsleadershipslack/documents-and-resources/blob/master/InclusiveLanguage.md) - Information about RLS's Slackbot that flags non-inclusive language and suggests alternatives, with resources to implement similar tools.
-* [Inclusive Language Reference (TSV)](https://github.com/randsleadershipslack/documents-and-resources/blob/master/RandsInclusiveLanguage.tsv) - The complete dataset of non-inclusive terms and suggested alternatives used by the RLS Slackbot for community-wide language guidance.
+* [How to Rands](https://github.com/randsleadershipslack/documents-and-resources/blob/main/howtorands.md) - A manager README template describing leadership style, working relationships, and communication preferences to accelerate team productivity.
+* [Inclusive Language](https://github.com/randsleadershipslack/documents-and-resources/blob/main/InclusiveLanguage.md) - Information about RLS's Slackbot that flags non-inclusive language and suggests alternatives, with resources to implement similar tools.
+* [Inclusive Language Reference (TSV)](https://github.com/randsleadershipslack/documents-and-resources/blob/main/RandsInclusiveLanguage.tsv) - The complete dataset of non-inclusive terms and suggested alternatives used by the RLS Slackbot for community-wide language guidance.
 * [Quick-Start Guide](https://github.com/randsleadershipslack/documents-and-resources/blob/main/rls-quick-start-guide.md) - An orientation guide for new members with essential information about navigating channels, community norms, and getting started in RLS.
 
 ## Legal
-* [LICENSE](https://github.com/randsleadershipslack/documents-and-resources/blob/master/LICENSE) - CC0 1.0 Universal license information, placing these documents in the public domain for unrestricted use and distribution.
+* [LICENSE](https://github.com/randsleadershipslack/documents-and-resources/blob/main/LICENSE) - CC0 1.0 Universal license information, placing these documents in the public domain for unrestricted use and distribution.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -17,8 +17,8 @@ The Rands Leadership Slack ("RLS") is an online community dedicated to the craft
   * [Don't Be a Troll](#dont-be-a-troll)
   * [Content Review Process](#content-review-process)
 - [Additional Situations](#additional-situations)
-  * [Incident Process](https://github.com/randsleadershipslack/documents-and-resources/blob/master/incident-process.md)
-  * [Deleting Content](https://github.com/randsleadershipslack/documents-and-resources/blob/master/deleting-content.md)
+  * [Incident Process](https://github.com/randsleadershipslack/documents-and-resources/blob/main/incident-process.md)
+  * [Deleting Content](https://github.com/randsleadershipslack/documents-and-resources/blob/main/deleting-content.md)
 - [Administrators](#administrators)
 
 # The Short Version
@@ -133,7 +133,7 @@ Some geographically focused channels have a higher tolerance for specific kinds 
 
 * In channels where commercial activity is allowed, it is just as unwelcome to post an unrelated commercial offering as it is to post in non-commercial channels.
 * Commercial requests via direct messages ("DM") without prior and apparent consent from the receiver are prohibited.
-* If you feel a message should be deleted, please refer to our overview of [Deleting Content](https://github.com/randsleadershipslack/documents-and-resources/blob/master/deleting-content.md).
+* If you feel a message should be deleted, please refer to our overview of [Deleting Content](https://github.com/randsleadershipslack/documents-and-resources/blob/main/deleting-content.md).
 
 ### Surveys
 
@@ -180,7 +180,7 @@ In the case that the Administrator's action is required because of a lack of res
 
 ## Additional Situations
 
-If you cannot resolve a situation peacefully, please refer to our [Incident Process](https://github.com/randsleadershipslack/documents-and-resources/blob/master/incident-process.md) and choose a course that suits the situation.
+If you cannot resolve a situation peacefully, please refer to our [Incident Process](https://github.com/randsleadershipslack/documents-and-resources/blob/main/incident-process.md) and choose a course that suits the situation.
 
 Suppose the Administrators determine that a member is violating any part of this Code of Conduct. In that case, they may take appropriate action, including expulsion and exclusion from the Rands Leadership Slack. Results of Administrator action are shared with involved members only and not the community.
 

--- a/deleting-content.md
+++ b/deleting-content.md
@@ -39,5 +39,4 @@ Direct messages between one or more members are private. Administators have no a
 
 ## Administrators
 
-The current roster of Administrators is maintained in the primary [Code of Conduct](https://github.com/randsleadershipslack/documents-and-resources/blob/master/code-of-conduct.md) document.
-
+The current roster of Administrators is maintained in the primary [Code of Conduct](https://github.com/randsleadershipslack/documents-and-resources/blob/main/code-of-conduct.md) document.

--- a/howtorands.md
+++ b/howtorands.md
@@ -76,6 +76,6 @@ If a meeting completes its intended purpose before it's scheduled to end, let's 
 
 **Humans stating opinions as facts** are a trigger for me. When I hear this, I will often unexpectedly jump into a conversation to clarify that your opinion is just that… your opinion and not a fact. 
 
-**This document is a [living breathing thing](https://github.com/randsleadershipslack/documents-and-resources/blob/master/howtorands.md)** and likely incomplete. I update it frequently and would appreciate your feedback.
+**This document is a [living breathing thing](https://github.com/randsleadershipslack/documents-and-resources/blob/main/howtorands.md)** and likely incomplete. I update it frequently and would appreciate your feedback.
 
 [^1]: Speculation: This document has an idea you'd like your manager to do. Thesis: Just because I have a practice or a belief doesn't mean it's the proper practice or belief for your manager. Suggestion: Ask your manager if they think my practice or belief is a good idea and see what happens. Feedback is a gift. 

--- a/incident-process.md
+++ b/incident-process.md
@@ -128,4 +128,4 @@ Incidents and their results are confidential to RLS Administrators and those inv
 
 ## Administrators
 
-The current roster of Administrators is maintained in the primary [Code of Conduct](https://github.com/randsleadershipslack/documents-and-resources/blob/master/code-of-conduct.md#administrators) document.
+The current roster of Administrators is maintained in the primary [Code of Conduct](https://github.com/randsleadershipslack/documents-and-resources/blob/main/code-of-conduct.md#administrators) document.


### PR DESCRIPTION
Github is not reliably redirecting from the old `master` branch` to the new `main` branch.